### PR TITLE
Add tempDir option

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ module.exports = function (options, process) {
   var outputDir = options.output || '.';
   var container = options.container || uuid.v4();
   var transform = new Transform({ objectMode: true });
-  var tempDir = path.join(osTempDir, container);
+  var tempBase = options.tempDir || osTempDir;
+  var tempDir = path.join(tempBase, container);
   var vinylFiles = [];
 
   if (options.container) {

--- a/readme.md
+++ b/readme.md
@@ -51,9 +51,16 @@ The directory read back into the stream when processing is finished. Relative to
 Type: `string`  
 Default: random uuid
 
-The directory that files are written to, relative to the operating system's temporary directry. Defaults to a unique random directory on every run.
+The directory that files are written to within tempDir. Defaults to a unique random directory on every run.
 
-The container is emptied before every run. 
+The container is emptied before every run.
+
+##### tempDir
+
+Type: `string`
+Default: OS default temp directory
+
+The directory to create container in. Defaults to the default temp directory for your OS.
 
 #### process(tempDir, cb, [fileProps])
 


### PR DESCRIPTION
This is step 1 of 2 to solve https://github.com/sindresorhus/gulp-ruby-sass/issues/121

Allows a configurable tempDir option to replace the OS default temp directory.
