### PR TITLE
Oct 2018 Dependency Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
-  - '0.10'
+  - '4'
+  - '6'
+  - '8'
+  - '10'

--- a/index.js
+++ b/index.js
@@ -4,11 +4,12 @@ var fs = require('fs');
 var path = require('path');
 var uuid = require('uuid');
 var glob = require('glob');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var osTempDir = require('os').tmpdir();
 var Transform = require('stream').Transform;
+var PluginError = require('plugin-error');
 
 var noopProcess = function(tempDir, callback) { callback(); };
 
@@ -42,7 +43,7 @@ module.exports = function (options, process) {
     }
 
     if (file.isStream()) {
-      this.emit('error', new gutil.PluginError('gulp-intermediate', 'Streaming not supported'));
+      this.emit('error', new PluginError('gulp-intermediate', 'Streaming not supported'));
       return cb();
     }
 
@@ -50,20 +51,20 @@ module.exports = function (options, process) {
 
     mkdirp(tempFileBase, function (err) {
       if (err) {
-        self.emit('error', new gutil.PluginError('gulp-intermediate', err));
+        self.emit('error', new PluginError('gulp-intermediate', err));
         return cb();
       }
 
       fs.writeFile(tempFilePath, file.contents, function(err)  {
         if (err) {
-          self.emit('error', new gutil.PluginError('gulp-intermediate', err));
+          self.emit('error', new PluginError('gulp-intermediate', err));
           return cb();
         }
 
         if (file.stat && file.stat.atime && file.stat.mtime) {
           fs.utimes(tempFilePath, file.stat.atime, file.stat.mtime, function(err)  {
             if (err) {
-              self.emit('error', new gutil.PluginError('gulp-intermediate', err));
+              self.emit('error', new PluginError('gulp-intermediate', err));
               return cb();
             }
 
@@ -86,7 +87,7 @@ module.exports = function (options, process) {
 
     process(tempDir, function(err) {
       if (err) {
-        self.emit('error', new gutil.PluginError('gulp-intermediate', err));
+        self.emit('error', new PluginError('gulp-intermediate', err));
         return cb();
       }
 
@@ -94,7 +95,7 @@ module.exports = function (options, process) {
 
       glob('**/*', { cwd: base }, function (err, files) {
         if (err) {
-          self.emit('error', new gutil.PluginError('gulp-intermediate', err));
+          self.emit('error', new PluginError('gulp-intermediate', err));
           return cb();
         }
 
@@ -103,7 +104,7 @@ module.exports = function (options, process) {
 
           // TODO: Can we make readFile async?
           if (fs.statSync(filePath).isFile()) {
-            self.push( new gutil.File({
+            self.push( new Vinyl({
               cwd: base,
               base: base,
               path: path.join(base, file),

--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
     "filesystem"
   ],
   "dependencies": {
-    "glob": "^4.0.0",
-    "gulp-util": "^2.2.0",
-    "rimraf": "^2.2.8",
-    "mkdirp": "^0.5.0",
-    "through2": "^0.5.1",
-    "uuid": "^1.4.1"
+    "glob": "^7.1.3",
+    "plugin-error": "^1.0.1",
+    "rimraf": "^2.6.2",
+    "through2": "^2.0.3",
+    "uuid": "^3.3.2",
+    "vinyl": "^2.2.0"
   },
   "devDependencies": {
-    "mocha": "*",
     "findit": "^1.2.0",
-    "mkdirp": "^0.5.0",
+    "mkdirp": "^0.5.1",
+    "mocha": "*",
     "underscore": "^1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "http://robwierzbowski.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.8.3"
   },
   "scripts": {
     "test": "mocha"

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var fs = require('fs');
 var path = require('path');
-var File = require('gulp-util').File;
+var Vinyl = require('vinyl');
 var findit = require('findit');
 var assert = require('assert');
 var mkdirp = require('mkdirp');
@@ -13,7 +13,7 @@ var outputDir = '_output';
 var cwd = __dirname;
 var base = path.join(cwd, 'test');
 var testFiles = [
-  new File({
+  new Vinyl({
     cwd: cwd,
     base: base,
     path: path.join(base, 'top_level.js'),
@@ -24,7 +24,7 @@ var testFiles = [
       ctime: new Date(2013,2,1,1,10)
     }
   }),
-  new File({
+  new Vinyl({
     cwd: cwd,
     base: base,
     path: path.join(base, 'directory', 'nested.js'),
@@ -35,7 +35,7 @@ var testFiles = [
       ctime: new Date(2013,2,1,1,10)
     }
   }),
-  new File({
+  new Vinyl({
     cwd: cwd,
     base: base,
     path: path.join(base, 'empty.js'),
@@ -130,19 +130,19 @@ it('copies files to a custom OS temp directory', function (done) {
 
 it('streams files from the output directory', function (done) {
   var processedFiles = [
-    new File ({
+    new Vinyl({
       cwd: cwd,
       base: base,
       path: path.join(base, 'puhoy.js'),
       contents: new Buffer('Generated!')
     }),
-    new File ({
+    new Vinyl({
       cwd: cwd,
       base: base,
       path: path.join(base, 'time_room/prismo.js'),
       contents: new Buffer('Re-generated!')
     }),
-    new File ({
+    new Vinyl({
       cwd: cwd,
       base: base,
       path: path.join(base, 'glob_world/GOLB.js'),


### PR DESCRIPTION
### GOAL

Update package dependencies, remove dependency on the deprecated `gulp-util`.

### CHANGES

- Replace `gulp-util` references with the recommended replacements (Vinyl, PluginError).
- Update to latest several other dependencies without breaking changes.

### TESTS

- Manually verified test pass in latest node v4, v6, v8, v10.  Note that v10 has a new deprecation warning I will address in a future PR.
 