### PR TITLE
Oct 2019 Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '8'
   - '10'
+  - '12'
 after_success:
   - npm run coveralls

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports = function (options, process) {
               cwd: base,
               base: base,
               path: path.join(base, file),
-              contents: new Buffer(fs.readFileSync(filePath))
+              contents: Buffer.from(fs.readFileSync(filePath))
             }));
           }
         });

--- a/package.json
+++ b/package.json
@@ -27,19 +27,19 @@
     "filesystem"
   ],
   "dependencies": {
-    "glob": "^7.1.3",
+    "glob": "^7.1.4",
     "mkdirp": "^0.5.1",
     "plugin-error": "^1.0.1",
-    "rimraf": "^2.6.2",
-    "through2": "^2.0.3",
-    "uuid": "^3.3.2",
+    "rimraf": "^3.0.0",
+    "through2": "^3.0.1",
+    "uuid": "^3.3.3",
     "vinyl": "^2.2.0"
   },
   "devDependencies": {
-    "coveralls": "^3.0.2",
-    "findit": "^1.2.0",
-    "mocha": "^5.2.0",
-    "nyc": "^12.0.2",
+    "coveralls": "^3.0.6",
+    "findit": "^2.0.0",
+    "mocha": "^6.2.1",
+    "nyc": "^14.1.1",
     "underscore": "^1.6.0"
   }
 }

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -20,7 +20,7 @@ describe('intermediate', function () {
         cwd: cwd,
         base: base,
         path: path.join(base, 'top_level.js'),
-        contents: new Buffer('Hey!'),
+        contents: Buffer.from('Hey!'),
         stat: {
           atime: new Date(2013,2,1,1,10),
           mtime: new Date(2013,2,1,1,10),
@@ -31,7 +31,7 @@ describe('intermediate', function () {
         cwd: cwd,
         base: base,
         path: path.join(base, 'directory', 'nested.js'),
-        contents: new Buffer('Ho!'),
+        contents: Buffer.from('Ho!'),
         stat: {
           atime: new Date(2013,2,1,1,10),
           mtime: new Date(2013,2,1,1,10),
@@ -42,7 +42,7 @@ describe('intermediate', function () {
         cwd: cwd,
         base: base,
         path: path.join(base, 'empty.js'),
-        contents: new Buffer('')
+        contents: Buffer.from('')
       })
     ];
   });
@@ -138,19 +138,19 @@ describe('intermediate', function () {
         cwd: cwd,
         base: base,
         path: path.join(base, 'puhoy.js'),
-        contents: new Buffer('Generated!')
+        contents: Buffer.from('Generated!')
       }),
       new Vinyl({
         cwd: cwd,
         base: base,
         path: path.join(base, 'time_room/prismo.js'),
-        contents: new Buffer('Re-generated!')
+        contents: Buffer.from('Re-generated!')
       }),
       new Vinyl({
         cwd: cwd,
         base: base,
         path: path.join(base, 'glob_world/GOLB.js'),
-        contents: new Buffer('')
+        contents: Buffer.from('')
       })
     ];
 


### PR DESCRIPTION
### Maintenance

- Update package dependencies
- Remove support for node v4
- Transition from `new Buffer()` to `Buffer.from()`